### PR TITLE
spreedly gem patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Spreedly Gem
 
+**This is a fork of the spreedly gem. We had to fork it due to the fact that it doesn't convert array data to xml here: https://github.com/spreedly/spreedly-gem/blob/master/lib/spreedly/environment.rb#L328. This fork has a very specific patch to fix our issue. We hope they will make a fix for us in their gem so we can go back to using it.**
+
 A convenient Ruby wrapper for the Spreedly API.
 
 This is an example Ruby integration with Spreedly. This version is no longer actively updated and will be superseded by a new version in the near future. Feature parity may lag behind, so please use this gem at your own risk.

--- a/lib/spreedly/environment.rb
+++ b/lib/spreedly/environment.rb
@@ -338,12 +338,12 @@ module Spreedly
       end.join
     end
 
-    def xml_for_array(key, array)
+    def xml_for_array(array)
       array.map do |value|
         if value.kind_of?(Hash)
-          "<#{key.singularize}>#{xml_for_hash(value)}</#{key.singularize}>"
+          xml_for_hash(value)
         else
-          "<#{key.singularize}>#{value}</#{key.singularize}>"
+          value.to_s
         end
       end.join
     end

--- a/lib/spreedly/environment.rb
+++ b/lib/spreedly/environment.rb
@@ -338,12 +338,12 @@ module Spreedly
       end.join
     end
 
-    def xml_for_array(array)
+    def xml_for_array(key, array)
       array.map do |value|
         if value.kind_of?(Hash)
-          xml_for_hash(value)
+          "<#{key.singularize}>#{xml_for_hash(value)}</#{key.singularize}>"
         else
-          value.to_s
+          "<#{key.singularize}>#{value}</#{key.singularize}>"
         end
       end.join
     end

--- a/lib/spreedly/environment.rb
+++ b/lib/spreedly/environment.rb
@@ -329,7 +329,7 @@ module Spreedly
       hash.map do |key, value|
         if value.kind_of?(Hash)
           text = xml_for_hash(value)
-        elsif value.kind_of?(Array)
+        elsif value.kind_of?(Array) && key == :line_items
           text = xml_for_array(value)
         else
           text = value

--- a/lib/spreedly/environment.rb
+++ b/lib/spreedly/environment.rb
@@ -327,8 +327,24 @@ module Spreedly
 
     def xml_for_hash(hash)
       hash.map do |key, value|
-        text = value.kind_of?(Hash) ? xml_for_hash(value) : value
+        if value.kind_of?(Hash)
+          text = xml_for_hash(value)
+        elsif value.kind_of?(Array)
+          text = xml_for_array(value)
+        else
+          text = value
+        end
         "<#{key}>#{text}</#{key}>"
+      end.join
+    end
+
+    def xml_for_array(array)
+      array.map do |value|
+        if value.kind_of?(Hash)
+          xml_for_hash(value)
+        else
+          value.to_s
+        end
       end.join
     end
 


### PR DESCRIPTION
This is a hacky/very specific fix intended to address our use case. We need to send an array of length 1 of line items to spreedly https://github.com/tremendous-rewards/core/blob/master/app/models/spreedly_payment.rb#L402, but their gem doesn't currently support that. This code adds a clause so that we will properly process arrays of length 1 with the key `:line_items`

Spreedly has told us they will fix this in their gem.